### PR TITLE
Support colons in MultiSelect option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 A strapi custom field for selecting multiple options from a provided list of items.
 
 ### CHANGELOG
+
+**1.2.2** Support colons in option values, only first colon is used as separator 
+
+> example usage: `this_is_label:all:of:this:is:value`
+
 **1.2.1** Localize option label
 
 > example usage: `my.custom.translations.key:value`
 
-**1.2.0** Replace strapi select with react-select**
 
+**1.2.0** Replace strapi select with react-select
 
 
 ## Installation

--- a/admin/src/components/MultiSelect/index.js
+++ b/admin/src/components/MultiSelect/index.js
@@ -67,7 +67,9 @@ const MultiSelect = ({
   const possibleOptions = useMemo(() => {
     return (attribute['options'] || [])
       .map((option) => {
-        const [label, value] = [...option.split(':'), option]
+        // Split the option by the first colon. If no colon exists, use the entire string as the value.
+        const [label, ...els] = option.split(':')
+        const value = els.length ? els.join(':') : label
         if (!label || !value) return null
         return { label, value }
       })

--- a/admin/src/components/MultiSelect/index.js
+++ b/admin/src/components/MultiSelect/index.js
@@ -67,9 +67,7 @@ const MultiSelect = ({
   const possibleOptions = useMemo(() => {
     return (attribute['options'] || [])
       .map((option) => {
-        // Split the option by the first colon. If no colon exists, use the entire string as the value.
-        const [label, ...els] = option.split(':')
-        const value = els.length ? els.join(':') : label
+        const [label, value] = [...option.split(/:(.*)/s), option]
         if (!label || !value) return null
         return { label, value }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "strapi-plugin-multi-select",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "custom-fields",
         "multi-select"
     ],
-    "version": "1.2.2",
+    "version": "1.2.3",
     "strapi": {
         "name": "multi-select",
         "description": "A strapi custom field for a multi select input.",


### PR DESCRIPTION
**Problem:** 
The previous implementation of `MultiSelect` component's option splitting logic did not allow colons (`:`) in the values. For an option like "foo:bar:baz", the label would be "foo" and the value would incorrectly be set as "bar" instead of "bar:baz".

**Solution:** 
This PR modifies the option splitting logic to treat everything after the first colon as the value. Now, for an option like "foo:bar:baz", the label is "foo" and the value is "bar:baz".

**Changes:**
- Updated the option splitting logic in the `MultiSelect` component.
- Added comments to clarify the behavior for future developers.
