### PR TITLE
Use proper isDisabled prop for disabled state

### DIFF
--- a/admin/src/components/MultiSelect/index.js
+++ b/admin/src/components/MultiSelect/index.js
@@ -106,7 +106,7 @@ const MultiSelect = ({
           error={fieldError}
           name={name}
           id={name}
-          disabled={disabled || possibleOptions.length === 0}
+          isDisabled={disabled || possibleOptions.length === 0}
           placeholder={placeholder}
           defaultValue={sanitizedValue.map((val) => ({
             label: formatMessage({


### PR DESCRIPTION
The `ReactSelect` component is basically a styled wrapper of '[react-select](https://github.com/JedWatson/react-select)'. That component has a disabled state, but it is using the `isDisabled` prop, while the multi-select passes a `disabled` prop. 

This means that currently the disabled state does not work; users can still interact with the multi-select when it should be disabled.